### PR TITLE
Task 6 pointers example

### DIFF
--- a/task6/task6.go
+++ b/task6/task6.go
@@ -14,6 +14,7 @@ func main() {
 	fmt.Printf("This is a = %d, b = %d, c = %d, d = %d, &a = %p,  &b = %p, *c = %v, *d = %v\n", 
 				a, b, c, d, &a, &b, *(*int)(c), *(*int)(d))
 	temp := uintptr(d) - uintptr(c)
+	fmt.Printf("Size of a = %d and b = %d\n", unsafe.Sizeof(a), unsafe.Sizeof(b))
 	if (temp > 0) {
 		fmt.Printf("Getting b via pointer to a = %v\n",*(*int)(unsafe.Pointer(uintptr(c) + temp)))
 		fmt.Printf("Getting a via pointer to b = %v",*(*int)(unsafe.Pointer(uintptr(d) - temp)))

--- a/task6/task6.go
+++ b/task6/task6.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+func main() {
+	fmt.Println("Actions with pointers")
+	a := 1
+	b := 2
+	c := unsafe.Pointer(&a)
+	d := unsafe.Pointer(&b)
+	fmt.Printf("This is a = %d, b = %d, c = %d, d = %d, &a = %p,  &b = %p, *c = %v, *d = %v\n", 
+				a, b, c, d, &a, &b, *(*int)(c), *(*int)(d))
+	temp := uintptr(d) - uintptr(c)
+	if (temp > 0) {
+		fmt.Printf("Getting b via pointer to a = %v\n",*(*int)(unsafe.Pointer(uintptr(c) + temp)))
+		fmt.Printf("Getting a via pointer to b = %v",*(*int)(unsafe.Pointer(uintptr(d) - temp)))
+	}
+}


### PR DESCRIPTION
At this example, I was trying to represent some action with pointers + address arithmetic:
Below example has been tested several times with different methods to get the variable data via another variable
1) the ouptut for code with no temp variable, just using the offset of 8 (8 bytes for int), at my example it is platform depended, so doesn't give exact bytes, but you can get it:
` unsafe.Sizeof(a) = 8`
for this peice of code:
```
fmt.Printf("Getting b via pointer to a = %v\n",*(*int)(unsafe.Pointer(uintptr(c) +8)))
fmt.Printf("Getting a via pointer to b = %v",*(*int)(unsafe.Pointer(uintptr(d) - 8)))
```
but the thing is for those variable the memory place is at heap, and it was quite often to get non - 8 bytes offcet:
Build log:
```
$ go build -gcflags="-l -m"
# _/C_/Users/jesun/Documents/geekbrains/go1_geekbrains/task6
.\task6.go:10:2: moved to heap: a
.\task6.go:11:2: moved to heap: b
.\task6.go:9:13: ... argument does not escape
.\task6.go:9:14: "Actions with pointers" escapes to heap
.\task6.go:14:12: ... argument does not escape
.\task6.go:14:13: a escapes to heap
.\task6.go:14:13: b escapes to heap
.\task6.go:15:25: *(*int)(c) escapes to heap
.\task6.go:15:37: *(*int)(d) escapes to heap
.\task6.go:18:13: ... argument does not escape
.\task6.go:18:50: *(*int)(unsafe.Pointer(uintptr(c) + 8)) escapes to heap
.\task6.go:19:13: ... argument does not escape
.\task6.go:19:48: *(*int)(unsafe.Pointer(uintptr(d) - 8)) escapes to heap
```
and could get the wrong result like this (however, sometimes the result was correct, really):
```
Actions with pointers
This is a = 1, b = 2, c = 824634384472, d = 824634384512, &a = 0xc0000a2058,  &b = 0xc0000a2080, *c = 1, *d = 2
Getting b via pointer to a = 8318823007734479427
Getting a via pointer to b = 375363759987
```
You may see that the offset between two variables (c and d) is much more bigger then just 8 bytes:
_824634384512 - 824634384472 = 40_ or 28 in HEX format (that one you can see for &a = 0xc0000a2058,  &b = 0xc0000a2080):
HEX: _0xc0000a2080 - 0xc0000a2058 = 28_
2) Then I added some simple calculation to extract the difference:
`temp := uintptr(d) - uintptr(c) `
which gave me correct calculation afterwords to get correct offset for that variable and I could then extract a via pointer to b and vice versa.
Does not matter how many times I run, I am getting correct result now:
```
$ go run task6.go 
Actions with pointers
This is a = 1, b = 2, c = 824633802928, d = 824633802936, &a = 0xc0000140b0,  &b = 0xc0000140b8, *c = 1, *d = 2
Size of a = 8 and b = 8
Getting b via pointer to a = 2
Getting a via pointer to b = 1
```